### PR TITLE
Update p5.gui.js to allow specifying whether the gui can be draggable or not.

### DIFF
--- a/libraries/p5.gui.js
+++ b/libraries/p5.gui.js
@@ -19,11 +19,11 @@
   // You only need to pass a reference to the sketch in instance mode
 
   // Usually you will call createGui(this, 'label');
-  p5.prototype.createGui = function(sketch, label, provider) {
+  p5.prototype.createGui = function(sketch, label, provider, draggable = true) {
 
     // createGui(label) signature
     if ((typeof sketch) === 'string') {
-      return this.createGui(label, sketch, provider);
+      return this.createGui(label, sketch, provider, draggable);
     }
 
     // normally the sketch will just be embedded below the body
@@ -52,7 +52,7 @@
     if(provider === 'QuickSettings') {
       if(QuickSettings) {
         console.log('Creating p5.gui powered by QuickSettings.');
-        gui = new QSGui(label, parent, sketch);
+        gui = new QSGui(label, parent, sketch, draggable);
       } else {
         console.log('QuickSettings not found. Is the script included in your HTML?');
         gui = new DummyGui(label, parent, sketch);
@@ -101,7 +101,7 @@
 
 
   // interface for quicksettings
-  function QSGui(label, parent, sketch) {
+  function QSGui(label, parent, sketch, draggable) {
 
     // hard code the position, it can be changed later
     let x = 20;
@@ -153,7 +153,7 @@
       qs.setPosition(x, y);
       return this;
     };
-
+    qs.setDraggable(draggable);
     // Extend Quicksettings
     // so it can magically create a GUI for parameters passed by name
     qs.bindParams = function(object, params) {


### PR DESCRIPTION
In the quicksettings.js file, there is a function called `setDraggable: function(draggable) {...}`, so I added a parameter named `draggable` to the `createGui` function in p5.gui.js with a default value of `true`, and passed that on to the `QSGui()` (which I added a parameter to, named `draggable`. Under the pass through functions, I called `qs.setDraggable(draggable)`, which successfully sets the gui's ability to be dragged.

There is one bug, however: The cursor displays a pointer instead of the default icon when `draggable` is set to false. I know it's supposed to do this when quicksettings' `this._draggable` is `true`, but I don't think it should be doing this when `this._draggable` is set to `false`.